### PR TITLE
Add basic routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@tiptap/react": "^2.1.10",
         "@tiptap/starter-kit": "^2.1.10",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.16.0"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -774,6 +775,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
+      "integrity": "sha512-bV63itrKBC0zdT27qYm6SDZHlkXwFL1xMBuhkn+X7l0+IIhNaH5wuuvZKp6eKhCD4KFhujhfhCT1YxXW6esUIA==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -4020,6 +4029,36 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/react-router": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.16.0.tgz",
+      "integrity": "sha512-VT4Mmc4jj5YyjpOi5jOf0I+TYzGpvzERy4ckNSvSh2RArv8LLoCxlsZ2D+tc7zgjxcY34oTz2hZaeX5RVprKqA==",
+      "dependencies": {
+        "@remix-run/router": "1.9.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.16.0.tgz",
+      "integrity": "sha512-aTfBLv3mk/gaKLxgRDUPbPw+s4Y/O+ma3rEN1u8EgEpLpPe6gNjIsWt9rxushMHHMb7mSwxRGdGlGdvmFsyPIg==",
+      "dependencies": {
+        "@remix-run/router": "1.9.0",
+        "react-router": "6.16.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@tiptap/react": "^2.1.10",
     "@tiptap/starter-kit": "^2.1.10",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.16.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,25 @@
 import './App.css'
 import Editor from './components/Editor'
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+} from 'react-router-dom'
+
+// TODO: create a home dashboard with create new button + list of user's docs
+function Home() {
+  return (<h1>Hello world</h1>)
+}
 
 function App() {
 
   return (
-    <>
-      <h1>Project Stardust</h1>
-      <Editor />
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/documents/:id" element={<Editor />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
 


### PR DESCRIPTION
Re-do https://github.com/dalla777/stardust/pull/4

Install react-router-dom and setup the two routes: Home and /documents/:id. Right now it will accept any id param for the Editor route since we don't have any data storage setup.

So the issue with the /documets/:id route not working had to do with how Netlify handles SPA apps. I had to add a "redirects" config to enable react router. See: https://docs.netlify.com/routing/redirects/rewrites-proxies/#history-pushstate-and-single-page-apps.