### PR TITLE
Add HocusPocus for concurrent users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hocuspocus/provider": "^2.5.0",
         "@hocuspocus/server": "^2.5.0",
+        "@tiptap/extension-character-count": "^2.1.11",
         "@tiptap/extension-collaboration": "^2.1.11",
         "@tiptap/extension-collaboration-cursor": "^2.1.11",
         "@tiptap/pm": "^2.1.10",
@@ -1154,6 +1155,19 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0"
+      }
+    },
+    "node_modules/@tiptap/extension-character-count": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-character-count/-/extension-character-count-2.1.11.tgz",
+      "integrity": "sha512-qR50YtvY+hgskUQSlHl/Bitx6xPJVQ2wuNWdw48s8LOjrE2cqAmAj7BmeBrh9481EbhgXZrt3m6UygFiMfiCiA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/pm": "^2.0.0"
       }
     },
     "node_modules/@tiptap/extension-code": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@tiptap/starter-kit": "^2.1.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^6.16.0"
+        "react-router-dom": "^6.16.0",
+        "yjs": "^13.6.8"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,16 @@
       "name": "stardust",
       "version": "0.0.0",
       "dependencies": {
+        "@hocuspocus/provider": "^2.5.0",
+        "@hocuspocus/server": "^2.5.0",
+        "@tiptap/extension-collaboration": "^2.1.11",
+        "@tiptap/extension-collaboration-cursor": "^2.1.11",
         "@tiptap/pm": "^2.1.10",
         "@tiptap/react": "^2.1.10",
         "@tiptap/starter-kit": "^2.1.10",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "yjs": "^13.6.8"
       },
       "devDependencies": {
         "@testing-library/react": "^14.0.0",
@@ -637,6 +642,66 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hocuspocus/common": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.5.0.tgz",
+      "integrity": "sha512-TpnQAb1Rtff1trwURFWaUEYZwqykaIGo6NNnMr6ZISdDZFWNHMAMUmy7dwJDS9ECnEtcjXhpPxXeLV+MVQXVnw==",
+      "dependencies": {
+        "lib0": "^0.2.47"
+      }
+    },
+    "node_modules/@hocuspocus/provider": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-2.5.0.tgz",
+      "integrity": "sha512-Du/q0kcVhaSQiKPBha19f+mnFOl4sFybARRWsGp4JIoDG+Vt3r73ZqjalIJmp9h4mBr2tGtS5zK/oQ/Vrv5/Bw==",
+      "dependencies": {
+        "@hocuspocus/common": "^2.5.0",
+        "@lifeomic/attempt": "^3.0.2",
+        "lib0": "^0.2.47",
+        "ws": "^7.5.9"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.6.4"
+      }
+    },
+    "node_modules/@hocuspocus/provider/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@hocuspocus/server": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/server/-/server-2.5.0.tgz",
+      "integrity": "sha512-7oopepZIdkU2XxJouVZSdsFTg2VaqwfM1so87VEY+b7DER68BS+rVb8Eimz9WER9ZLLyg5DK+t797rnXJX/1cQ==",
+      "dependencies": {
+        "@hocuspocus/common": "^2.5.0",
+        "async-lock": "^1.3.1",
+        "kleur": "^4.1.4",
+        "lib0": "^0.2.47",
+        "uuid": "^9.0.0",
+        "ws": "^8.5.0"
+      },
+      "peerDependencies": {
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.6.4"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -687,6 +752,11 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "node_modules/@lifeomic/attempt": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@lifeomic/attempt/-/attempt-3.0.3.tgz",
+      "integrity": "sha512-GlM2AbzrErd/TmLL3E8hAHmb5Q7VhDJp35vIbyPVA5Rz55LZuRr8pwL3qrwwkVNo05gMX1J44gURKb4MHQZo7w=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1109,6 +1179,33 @@
       "peerDependencies": {
         "@tiptap/core": "^2.0.0",
         "@tiptap/pm": "^2.0.0"
+      }
+    },
+    "node_modules/@tiptap/extension-collaboration": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-2.1.11.tgz",
+      "integrity": "sha512-f/O0XHIUqQEaQ/gwG9tlhcO7Vmt02EeCWWvuLySvR8VaGGfxl6n72WQHpRpQcxxL+IB4Kp/Al4vijfrDw6gqzA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/pm": "^2.0.0",
+        "y-prosemirror": "1.0.20"
+      }
+    },
+    "node_modules/@tiptap/extension-collaboration-cursor": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration-cursor/-/extension-collaboration-cursor-2.1.11.tgz",
+      "integrity": "sha512-IRLqVGwQo8l715VWzyGr+RUuFfQFLB2BsSSy9w5JSekBMbFd7OZcLFXjvwQnQjGqtzPZcc3D1dPCZd/Za17fXg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "y-prosemirror": "1.0.20"
       }
     },
     "node_modules/@tiptap/extension-document": {
@@ -1925,6 +2022,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.0.tgz",
+      "integrity": "sha512-coglx5yIWuetakm3/1dsX9hxCNox22h7+V80RQOu2XUUMidtArxKoZoOtHUPuR84SycKTXzgGzAUR5hJxujyJQ=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -3227,6 +3329,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3277,6 +3388,14 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3288,6 +3407,25 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.85",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.85.tgz",
+      "integrity": "sha512-vtAhVttLXCu3ps2OIsTz8CdKYKdcMo7ds1MNBIcSXz6vrY8sxASqpTi4vmsAIn7xjWvyT7haKcWW6woP6jebjQ==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/linkify-it": {
@@ -4432,6 +4570,18 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "4.4.9",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
@@ -4709,11 +4859,87 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y-prosemirror": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.0.20.tgz",
+      "integrity": "sha512-LVMtu3qWo0emeYiP+0jgNcvZkqhzE/otOoro+87q0iVKxy/sMKuiJZnokfJdR4cn9qKx0Un5fIxXqbAlR2bFkA==",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.3.2"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yjs": {
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -5,17 +5,23 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "serve": "node src/server/index.js",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "test": "vitest"
   },
   "dependencies": {
+    "@hocuspocus/provider": "^2.5.0",
+    "@hocuspocus/server": "^2.5.0",
+    "@tiptap/extension-collaboration": "^2.1.11",
+    "@tiptap/extension-collaboration-cursor": "^2.1.11",
     "@tiptap/pm": "^2.1.10",
     "@tiptap/react": "^2.1.10",
     "@tiptap/starter-kit": "^2.1.10",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "yjs": "^13.6.8"
   },
   "devDependencies": {
     "@testing-library/react": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@hocuspocus/provider": "^2.5.0",
     "@hocuspocus/server": "^2.5.0",
+    "@tiptap/extension-character-count": "^2.1.11",
     "@tiptap/extension-collaboration": "^2.1.11",
     "@tiptap/extension-collaboration-cursor": "^2.1.11",
     "@tiptap/pm": "^2.1.10",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -17,8 +17,7 @@ const ydoc = new Y.Doc(); // grab from db
 const websocketProvider = new HocuspocusProvider({
   url: "ws://127.0.0.1:80",
   name: "example-document-room-id",
-  document: ydoc,
-  maxAttempts: 5,
+  document: ydoc
 });
 
 const colors = ['#958DF1', '#F98181', '#FBBC88', '#FAF594', '#70CFF8', '#94FADB', '#B9F18D']

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,18 +1,38 @@
 import { EditorProvider } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import Collaboration from '@tiptap/extension-collaboration'
+import CollaborationCursor from '@tiptap/extension-collaboration-cursor'
+import * as Y from 'yjs'
+import { HocuspocusProvider } from '@hocuspocus/provider'
 import MenuBar from './MenuBar'
 import './editor.css'
 
+const ydoc = new Y.Doc(); // grab from db
+
+const provider = new HocuspocusProvider({
+  url: "ws://0.0.0.0:1234",
+  name: "example-document-room-id",
+  document: ydoc,
+});
+
 const extensions = [
   StarterKit.configure({
+    history: false,
     bulletList: {
       keepMarks: true,
-      keepAttributes: false, // TODO : Making this as `false` becase marks are not preserved when I try to preserve attrs, awaiting a bit of help
+      keepAttributes: false,
     },
     orderedList: {
       keepMarks: true,
-      keepAttributes: false, // TODO : Making this as `false` becase marks are not preserved when I try to preserve attrs, awaiting a bit of help
+      keepAttributes: false,
     },
+  }),
+  Collaboration.configure({
+    document: ydoc,
+  }),
+  CollaborationCursor.configure({
+    provider,
+    user: { name: "John Doe", color: "#ffcc00" },
   }),
 ]
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -18,6 +18,7 @@ const websocketProvider = new HocuspocusProvider({
   url: "ws://127.0.0.1:80",
   name: "example-document-room-id",
   document: ydoc,
+  maxAttempts: 5,
 });
 
 const colors = ['#958DF1', '#F98181', '#FBBC88', '#FAF594', '#70CFF8', '#94FADB', '#B9F18D']
@@ -70,9 +71,12 @@ const Editor = () => {
     ]
   })
 
-    useEffect(() => {
+  useEffect(() => {
     // Update status changes
       websocketProvider.on('status', (event: HocuspocusProviderWebsocket) => {
+        setStatus(event.status)
+      })
+      websocketProvider.off('status', (event: HocuspocusProviderWebsocket) => {
         setStatus(event.status)
       })
   }, [])

--- a/src/components/MenuBar.tsx
+++ b/src/components/MenuBar.tsx
@@ -1,7 +1,6 @@
-import { useCurrentEditor } from '@tiptap/react'
+import { Editor } from '@tiptap/react'
 
-const MenuBar = () => {
-    const { editor } = useCurrentEditor()
+const MenuBar = ({ editor }: { editor: Editor }) => {
   
     if (!editor) {
       return null

--- a/src/components/editor.css
+++ b/src/components/editor.css
@@ -56,3 +56,60 @@
   border-top: 2px solid rgba(#0D0D0D, 0.1);
   margin: 2rem 0;
 }
+
+/* Give a remote user a caret */
+.collaboration-cursor__caret {
+  border-left: 1px solid #0d0d0d;
+  border-right: 1px solid #0d0d0d;
+  margin-left: -1px;
+  margin-right: -1px;
+  pointer-events: none;
+  position: relative;
+  word-break: normal;
+}
+
+/* Render the username above the caret */
+.collaboration-cursor__label {
+  border-radius: 3px 3px 3px 0;
+  color: #0d0d0d;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 600;
+  left: -1px;
+  line-height: normal;
+  padding: 0.1rem 0.3rem;
+  position: absolute;
+  top: -1.4em;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.editor__footer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.editor__status {
+  align-items: center;
+  border-radius: 5px;
+  display: flex;
+}
+
+.editor__status::before {
+  background: rgba(#0d0d0d, 0.5);
+  border-radius: 50%;
+  content: " ";
+  display: inline-block;
+  flex: 0 0 auto;
+  height: 0.5rem;
+  margin-right: 0.5rem;
+  width: 0.5rem;
+}
+
+.editor__status--connecting::before {
+  background: #616161;
+}
+
+.editor__status--connected::before {
+  background: #b9f18d;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,7 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  <App />
 )

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,0 +1,8 @@
+import { Hocuspocus } from "@hocuspocus/server";
+
+// Configure the server …
+const server = new Hocuspocus({
+    port: 1234,
+  });
+  
+server.listen();

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,7 +2,7 @@ import { Hocuspocus } from "@hocuspocus/server";
 
 // Configure the server …
 const server = new Hocuspocus({
-    port: 1234,
+    port: 80,
   });
   
 server.listen();


### PR DESCRIPTION
This is a pretty barebones (mostly the example) version of getting multi-user cursors and status going. I did change from using the editor provider/context to using the editor hook, as I saw no other obvious way of getting that state in order up update the current user. 

In order to run this locally, you'll need to run the server AND the dev server (vite). So in one window, `npm run serve` and in the other `npm run dev`. In order to see the cursors, you'll need to open 2 different browsers (yes, I mean *browsers*, not browser windows--we keep the username in localstorage, so if you use the same browser, it will just give everyone the same name). There's an "add your name" button where you can do that, and voilà.

I also added a character limit, since we wanted to add these to a db for real. Currently, this is just using localhost and the same room for everyone; once we add actual docs, we can add the rooms for those particular docs.

I did notice that after I pulled in the routing work, suddenly the status indicator broke on safari, although the updates and cursor flag are coming through. I'm not really sure why that would happen, any thoughts appreciated.