### PR TITLE
Fix event cleanup

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -72,12 +72,8 @@ const Editor = () => {
 
   useEffect(() => {
     // Update status changes
-      websocketProvider.on('status', (event: HocuspocusProviderWebsocket) => {
-        setStatus(event.status)
-      })
-      websocketProvider.off('status', (event: HocuspocusProviderWebsocket) => {
-        setStatus(event.status)
-      })
+      websocketProvider.on('status', (event: HocuspocusProviderWebsocket) => setStatus(event.status))
+      websocketProvider.off('status', (event: HocuspocusProviderWebsocket) => setStatus(event.status))
   }, [])
 
   useEffect(() => {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -72,9 +72,11 @@ const Editor = () => {
 
   useEffect(() => {
     // Update status changes
-    const statusChange = (event: HocuspocusProviderWebsocket) => setStatus(event.status);
-    websocketProvider.on('status', statusChange);
-    websocketProvider.off('status', statusChange);
+    const statusChange = (event: HocuspocusProviderWebsocket) => setStatus(event.status)
+    websocketProvider.on('status', statusChange)
+    return () => {
+      websocketProvider.off('status', statusChange)
+    }
   }, [])
 
   useEffect(() => {

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -72,8 +72,9 @@ const Editor = () => {
 
   useEffect(() => {
     // Update status changes
-      websocketProvider.on('status', (event: HocuspocusProviderWebsocket) => setStatus(event.status))
-      websocketProvider.off('status', (event: HocuspocusProviderWebsocket) => setStatus(event.status))
+    const statusChange = (event: HocuspocusProviderWebsocket) => setStatus(event.status);
+    websocketProvider.on('status', statusChange);
+    websocketProvider.off('status', statusChange);
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
Took a minute to recall that the return method of an `effect` is what gets called at unmount. 🤦‍♀️ 